### PR TITLE
Implement initial JSON data model

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -35,7 +35,20 @@ function App() {
       <div className="mb-4">
         <input type="file" accept="application/json" onChange={handleFile} />
       </div>
-      <button className="bg-blue-500 text-white px-4 py-2 rounded" onClick={handleSave} disabled={!project}>
+      {project && (
+        <div className="mb-4">
+          <p className="font-bold">{project.name}</p>
+          <p>
+            {project.dimensions.length} x {project.dimensions.width} /{' '}
+            {project.dimensions.maxLoadHeight}
+          </p>
+        </div>
+      )}
+      <button
+        className="bg-blue-500 text-white px-4 py-2 rounded"
+        onClick={handleSave}
+        disabled={!project}
+      >
         Zapisz
       </button>
     </div>

--- a/pal-in/src/data/interfaces.ts
+++ b/pal-in/src/data/interfaces.ts
@@ -1,24 +1,61 @@
-export const PPB_VERSION_NO = 1;
+export const PPB_VERSION_NO = '3.1.1'
 
 export interface Dimensions {
-  x: number;
-  y: number;
-  z: number;
+  /** pallet length */
+  length: number
+  /** pallet width */
+  width: number
+  /** allowed load height */
+  maxLoadHeight: number
+  /** pallet height */
+  palletHeight: number
 }
 
-export interface ProductDimensions extends Dimensions {}
-
-export type LayerType = 'single' | 'double';
+export interface ProductDimensions {
+  length: number
+  width: number
+  height: number
+  weight: number
+}
 
 export interface PatternItem {
-  id: string;
-  weight: number;
+  /** x position on the pallet */
+  x: number
+  /** y position on the pallet */
+  y: number
+  /** rotation */
+  r: number
+  /** optional grouping id */
+  g?: number
+  /** optional flip/index */
+  f?: number
+}
+
+export interface LayerDefinition {
+  name: string
+  class: 'layer' | 'separator'
+  height?: number
+  pattern?: PatternItem[]
+  altPattern?: PatternItem[]
+  approach?: string
+  altApproach?: string
+}
+
+export interface GuiSettings {
+  PPB_VERSION_NO: string
+  altLayout?: string
+  [key: string]: unknown
 }
 
 export interface PalletProject {
-  PPB_VERSION_NO: number;
-  name: string;
-  dimensions: ProductDimensions;
-  items: PatternItem[];
-  layerType: LayerType;
+  name: string
+  description?: string
+  dimensions: Dimensions
+  productDimensions: ProductDimensions
+  maxGrip?: number
+  maxGripAuto?: boolean
+  labelOrientation?: string
+  guiSettings: GuiSettings
+  layerTypes: LayerDefinition[]
+  layers: string[]
 }

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -1,16 +1,69 @@
-import { PPB_VERSION_NO } from './interfaces';
-import type { PalletProject } from './interfaces';
+import { PPB_VERSION_NO } from './interfaces'
+import type { PalletProject, PatternItem } from './interfaces'
+
+function validatePattern(
+  pattern: PatternItem[] | undefined,
+  width: number,
+  length: number,
+) {
+  if (!pattern) return
+  for (const item of pattern) {
+    if (
+      item.x < 0 ||
+      item.y < 0 ||
+      item.x > width ||
+      item.y > length
+    ) {
+      throw new Error('Pattern item outside pallet bounds')
+    }
+  }
+}
 
 export async function loadFromFile(file: File): Promise<PalletProject> {
-  const text = await file.text();
-  const data = JSON.parse(text);
-  if (data.PPB_VERSION_NO !== PPB_VERSION_NO) {
-    throw new Error('Invalid PPB version');
+  const text = await file.text()
+  const data = JSON.parse(text)
+
+  if (!data.guiSettings || data.guiSettings.PPB_VERSION_NO !== PPB_VERSION_NO) {
+    throw new Error('Unsupported PPB version')
   }
-  return data as PalletProject;
+
+  if (!data.dimensions || !data.productDimensions) {
+    throw new Error('Missing dimension information')
+  }
+  if (
+    data.dimensions.length <= 0 ||
+    data.dimensions.width <= 0 ||
+    data.productDimensions.length <= 0 ||
+    data.productDimensions.width <= 0 ||
+    data.productDimensions.height <= 0
+  ) {
+    throw new Error('Invalid dimensions')
+  }
+
+  if (!Array.isArray(data.layerTypes) || !Array.isArray(data.layers)) {
+    throw new Error('Invalid layer data')
+  }
+
+  const typeNames = new Set<string>(
+    data.layerTypes.map((lt: { name: string }) => lt.name),
+  )
+  for (const name of data.layers) {
+    if (!typeNames.has(name)) {
+      throw new Error('Layer reference not found: ' + name)
+    }
+  }
+
+  for (const lt of data.layerTypes) {
+    validatePattern(lt.pattern, data.dimensions.width, data.dimensions.length)
+    validatePattern(lt.altPattern, data.dimensions.width, data.dimensions.length)
+  }
+
+  return data as PalletProject
 }
 
 export function saveToFile(project: PalletProject): Blob {
-  const data = JSON.stringify(project, null, 2);
-  return new Blob([data], { type: 'application/json' });
+  if (!project.guiSettings) project.guiSettings = { PPB_VERSION_NO }
+  project.guiSettings.PPB_VERSION_NO = PPB_VERSION_NO
+  const data = JSON.stringify(project, null, 2)
+  return new Blob([data], { type: 'application/json' })
 }


### PR DESCRIPTION
## Summary
- expand data interfaces to match Pally JSON
- add validation when loading projects
- ensure saved projects keep the expected version field
- display loaded project information in the demo

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685123cb24ec8325958532b7f46f9f60