### PR TITLE
Add pallet configuration form

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -2,15 +2,79 @@ import { useState } from 'react'
 import './App.css'
 import { loadFromFile, saveToFile } from './data/jsonIO'
 import type { PalletProject } from './data/interfaces'
+import { PPB_VERSION_NO } from './data/interfaces'
+
+const MM_TO_INCH = 25.4
+
+const defaultProject: PalletProject = {
+  name: 'New Project',
+  dimensions: {
+    length: 1200,
+    width: 800,
+    maxLoadHeight: 1200,
+    palletHeight: 150,
+  },
+  productDimensions: {
+    length: 200,
+    width: 200,
+    height: 200,
+    weight: 1,
+  },
+  labelOrientation: '0',
+  units: 'mm',
+  overhang: 0,
+  guiSettings: { PPB_VERSION_NO },
+  layerTypes: [],
+  layers: [],
+}
 
 function App() {
-  const [project, setProject] = useState<PalletProject | null>(null)
+  const [project, setProject] = useState<PalletProject>(defaultProject)
+
+  const updateDimensions = (key: keyof typeof project.dimensions, value: number) => {
+    setProject((prev) => ({
+      ...prev,
+      dimensions: { ...prev.dimensions, [key]: value },
+    }))
+  }
+
+  const updateProduct = (key: keyof typeof project.productDimensions, value: number) => {
+    setProject((prev) => ({
+      ...prev,
+      productDimensions: { ...prev.productDimensions, [key]: value },
+    }))
+  }
+
+  const convertProjectUnits = (p: PalletProject, to: 'mm' | 'inch'): PalletProject => {
+    if (p.units === to) return p
+    const factor = to === 'mm' ? MM_TO_INCH : 1 / MM_TO_INCH
+    const convert = (n: number) => parseFloat((n * factor).toFixed(2))
+    return {
+      ...p,
+      units: to,
+      dimensions: {
+        length: convert(p.dimensions.length),
+        width: convert(p.dimensions.width),
+        maxLoadHeight: convert(p.dimensions.maxLoadHeight),
+        palletHeight: convert(p.dimensions.palletHeight),
+      },
+      productDimensions: {
+        ...p.productDimensions,
+        length: convert(p.productDimensions.length),
+        width: convert(p.productDimensions.width),
+        height: convert(p.productDimensions.height),
+      },
+      overhang: p.overhang !== undefined ? convert(p.overhang) : p.overhang,
+    }
+  }
 
   const handleFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0]
     if (file) {
       try {
         const proj = await loadFromFile(file)
+        if (!proj.units) proj.units = 'mm'
+        if (proj.overhang === undefined) proj.overhang = 0
         setProject(proj)
         alert('Loaded project ' + proj.name)
       } catch (err) {
@@ -20,7 +84,6 @@ function App() {
   }
 
   const handleSave = () => {
-    if (!project) return
     const blob = saveToFile(project)
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -35,19 +98,125 @@ function App() {
       <div className="mb-4">
         <input type="file" accept="application/json" onChange={handleFile} />
       </div>
-      {project && (
-        <div className="mb-4">
-          <p className="font-bold">{project.name}</p>
-          <p>
-            {project.dimensions.length} x {project.dimensions.width} /{' '}
-            {project.dimensions.maxLoadHeight}
-          </p>
+      <div className="mb-4 flex flex-col gap-2 max-w-md mx-auto text-left">
+        <div>
+          <label className="mr-2">Units</label>
+          <select
+            className="border"
+            value={project.units}
+            onChange={(e) =>
+              setProject((p) => convertProjectUnits(p, e.target.value as 'mm' | 'inch'))
+            }
+          >
+            <option value="mm">mm</option>
+            <option value="inch">inch</option>
+          </select>
         </div>
-      )}
+        <div>
+          <label className="mr-2">Pallet length</label>
+          <input
+            className="border"
+            type="number"
+            value={project.dimensions.length}
+            onChange={(e) => updateDimensions('length', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Pallet width</label>
+          <input
+            className="border"
+            type="number"
+            value={project.dimensions.width}
+            onChange={(e) => updateDimensions('width', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Pallet height</label>
+          <input
+            className="border"
+            type="number"
+            value={project.dimensions.palletHeight}
+            onChange={(e) => updateDimensions('palletHeight', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Stack height</label>
+          <input
+            className="border"
+            type="number"
+            value={project.dimensions.maxLoadHeight}
+            onChange={(e) => updateDimensions('maxLoadHeight', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Product length</label>
+          <input
+            className="border"
+            type="number"
+            value={project.productDimensions.length}
+            onChange={(e) => updateProduct('length', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Product width</label>
+          <input
+            className="border"
+            type="number"
+            value={project.productDimensions.width}
+            onChange={(e) => updateProduct('width', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Product height</label>
+          <input
+            className="border"
+            type="number"
+            value={project.productDimensions.height}
+            onChange={(e) => updateProduct('height', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Product weight</label>
+          <input
+            className="border"
+            type="number"
+            value={project.productDimensions.weight}
+            onChange={(e) => updateProduct('weight', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Overhang</label>
+          <input
+            className="border"
+            type="number"
+            value={project.overhang}
+            onChange={(e) =>
+              setProject((prev) => ({ ...prev, overhang: e.target.valueAsNumber }))
+            }
+          />
+        </div>
+        <div>
+          <label className="mr-2">Label orientation</label>
+          <input
+            className="border"
+            type="text"
+            value={project.labelOrientation}
+            onChange={(e) =>
+              setProject((prev) => ({ ...prev, labelOrientation: e.target.value }))
+            }
+          />
+        </div>
+      </div>
+      <div className="mb-4">
+        <p className="font-bold">{project.name}</p>
+        <p>
+          {project.dimensions.length} x {project.dimensions.width} /{' '}
+          {project.dimensions.maxLoadHeight}
+        </p>
+      </div>
       <button
         className="bg-blue-500 text-white px-4 py-2 rounded"
         onClick={handleSave}
-        disabled={!project}
       >
         Zapisz
       </button>

--- a/pal-in/src/data/interfaces.ts
+++ b/pal-in/src/data/interfaces.ts
@@ -55,6 +55,10 @@ export interface PalletProject {
   maxGrip?: number
   maxGripAuto?: boolean
   labelOrientation?: string
+  /** unit system used for dimensions */
+  units?: 'mm' | 'inch'
+  /** product overhang beyond pallet edge */
+  overhang?: number
   guiSettings: GuiSettings
   layerTypes: LayerDefinition[]
   layers: string[]


### PR DESCRIPTION
## Summary
- create `PalletProject` defaults and extend interface with `units` and `overhang`
- add form fields in `App.tsx` for pallet/product sizes, overhang, stack height, label orientation and units
- implement unit conversion when switching between mm and inch

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6851310b66cc8325b9983e40e4737990