### PR TITLE
Add example pallet project

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,7 @@ Create a production build:
 npm run build
 ```
 
+
+## Example Project
+
+A sample pallet project JSON is provided in `examples/sample-project.json`. Load this file in the demo application to quickly verify that loading and saving work.

--- a/examples/sample-project.json
+++ b/examples/sample-project.json
@@ -1,0 +1,30 @@
+{
+  "name": "Example Project",
+  "description": "Sample project for quick testing",
+  "dimensions": {
+    "length": 1200,
+    "width": 800,
+    "maxLoadHeight": 1600,
+    "palletHeight": 150
+  },
+  "productDimensions": {
+    "length": 200,
+    "width": 200,
+    "height": 100,
+    "weight": 5
+  },
+  "maxGrip": 0,
+  "guiSettings": {
+    "PPB_VERSION_NO": "3.1.1"
+  },
+  "layerTypes": [
+    {
+      "name": "default",
+      "class": "layer",
+      "pattern": [
+        { "x": 0, "y": 0, "r": 0 }
+      ]
+    }
+  ],
+  "layers": ["default"]
+}


### PR DESCRIPTION
## Summary
- add `examples/` folder with a simple pallet project JSON
- mention example file in README for quick testing

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6851310f00a8832583292a7ed2b82278