### PR TITLE
Add units field to sample project

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ npm run build
 ## Example Project
 
 A sample pallet project JSON is provided in `examples/sample-project.json`. Load this file in the demo application to quickly verify that loading and saving work.
+
+When creating your own JSON files, include a `"units"` field at the top level to
+choose between millimetres (`"mm"`) and inches (`"inch"`). All dimension values
+use these units.

--- a/examples/sample-project.json
+++ b/examples/sample-project.json
@@ -1,6 +1,7 @@
 {
   "name": "Example Project",
   "description": "Sample project for quick testing",
+  "units": "mm",
   "dimensions": {
     "length": 1200,
     "width": 800,


### PR DESCRIPTION
## Summary
- add `units` field to sample-project.json so its dimensions explicitly use millimeters
- document how to specify measurement units when creating pallet project JSON files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68513675f1408325ac8e20e7ecdefb9e