### PR TITLE
Update overhang fields to separate sides and ends

### DIFF
--- a/examples/sample-project.json
+++ b/examples/sample-project.json
@@ -13,6 +13,8 @@
     "height": 100,
     "weight": 5
   },
+  "overhangSides": 0,
+  "overhangEnds": 0,
   "maxGrip": 0,
   "guiSettings": {
     "PPB_VERSION_NO": "3.1.1"

--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -22,7 +22,8 @@ const defaultProject: PalletProject = {
   },
   labelOrientation: '0',
   units: 'mm',
-  overhang: 0,
+  overhangSides: 0,
+  overhangEnds: 0,
   guiSettings: { PPB_VERSION_NO },
   layerTypes: [],
   layers: [],
@@ -64,7 +65,10 @@ function App() {
         width: convert(p.productDimensions.width),
         height: convert(p.productDimensions.height),
       },
-      overhang: p.overhang !== undefined ? convert(p.overhang) : p.overhang,
+      overhangSides:
+        p.overhangSides !== undefined ? convert(p.overhangSides) : p.overhangSides,
+      overhangEnds:
+        p.overhangEnds !== undefined ? convert(p.overhangEnds) : p.overhangEnds,
     }
   }
 
@@ -74,7 +78,8 @@ function App() {
       try {
         const proj = await loadFromFile(file)
         if (!proj.units) proj.units = 'mm'
-        if (proj.overhang === undefined) proj.overhang = 0
+        if (proj.overhangSides === undefined) proj.overhangSides = 0
+        if (proj.overhangEnds === undefined) proj.overhangEnds = 0
         setProject(proj)
         alert('Loaded project ' + proj.name)
       } catch (err) {
@@ -185,13 +190,30 @@ function App() {
           />
         </div>
         <div>
-          <label className="mr-2">Overhang</label>
+          <label className="mr-2">Overhang sides</label>
           <input
             className="border"
             type="number"
-            value={project.overhang}
+            value={project.overhangSides}
             onChange={(e) =>
-              setProject((prev) => ({ ...prev, overhang: e.target.valueAsNumber }))
+              setProject((prev) => ({
+                ...prev,
+                overhangSides: e.target.valueAsNumber,
+              }))
+            }
+          />
+        </div>
+        <div>
+          <label className="mr-2">Overhang ends</label>
+          <input
+            className="border"
+            type="number"
+            value={project.overhangEnds}
+            onChange={(e) =>
+              setProject((prev) => ({
+                ...prev,
+                overhangEnds: e.target.valueAsNumber,
+              }))
             }
           />
         </div>

--- a/pal-in/src/data/interfaces.ts
+++ b/pal-in/src/data/interfaces.ts
@@ -57,8 +57,10 @@ export interface PalletProject {
   labelOrientation?: string
   /** unit system used for dimensions */
   units?: 'mm' | 'inch'
-  /** product overhang beyond pallet edge */
-  overhang?: number
+  /** product overhang beyond pallet sides */
+  overhangSides?: number
+  /** product overhang beyond pallet ends */
+  overhangEnds?: number
   guiSettings: GuiSettings
   layerTypes: LayerDefinition[]
   layers: string[]

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -78,6 +78,19 @@ export async function loadFromFile(file: File): Promise<PalletProject> {
     throw new Error('Invalid alt layout')
   }
 
+  if (
+    data.overhangSides !== undefined &&
+    typeof data.overhangSides !== 'number'
+  ) {
+    throw new Error('Invalid overhangSides value')
+  }
+  if (
+    data.overhangEnds !== undefined &&
+    typeof data.overhangEnds !== 'number'
+  ) {
+    throw new Error('Invalid overhangEnds value')
+  }
+
   const typeNames = new Set<string>(
     data.layerTypes.map((lt: { name: string }) => lt.name),
   )


### PR DESCRIPTION
## Summary
- replace `overhang` field with `overhangSides` and `overhangEnds`
- handle new fields when reading/writing JSON
- convert both overhang values during unit conversion
- provide UI inputs for side and end overhangs
- update example project with new keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68513671b2588325a030febf70ca332b