### PR TITLE
Add maxGrip editing and validation

### DIFF
--- a/examples/sample-project.json
+++ b/examples/sample-project.json
@@ -14,6 +14,7 @@
     "weight": 5
   },
   "maxGrip": 0,
+  "maxGripAuto": false,
   "guiSettings": {
     "PPB_VERSION_NO": "3.1.1"
   },

--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -20,6 +20,8 @@ const defaultProject: PalletProject = {
     height: 200,
     weight: 1,
   },
+  maxGrip: 0,
+  maxGripAuto: false,
   labelOrientation: '0',
   units: 'mm',
   overhang: 0,
@@ -182,6 +184,28 @@ function App() {
             type="number"
             value={project.productDimensions.weight}
             onChange={(e) => updateProduct('weight', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Max grip</label>
+          <input
+            className="border"
+            type="number"
+            value={project.maxGrip}
+            onChange={(e) =>
+              setProject((prev) => ({ ...prev, maxGrip: e.target.valueAsNumber }))
+            }
+          />
+        </div>
+        <div>
+          <label className="mr-2">Max grip auto</label>
+          <input
+            className="border"
+            type="checkbox"
+            checked={project.maxGripAuto}
+            onChange={(e) =>
+              setProject((prev) => ({ ...prev, maxGripAuto: e.target.checked }))
+            }
           />
         </div>
         <div>

--- a/pal-in/src/data/jsonIO.test.ts
+++ b/pal-in/src/data/jsonIO.test.ts
@@ -37,6 +37,12 @@ describe('loadFromFile', () => {
     const file = new File([JSON.stringify(bad)], 'p.json')
     await expect(loadFromFile(file)).rejects.toThrow('Pattern item outside pallet bounds')
   })
+
+  test('rejects non-integer maxGrip', async () => {
+    const bad = { ...baseProject, maxGrip: 1.5 }
+    const file = new File([JSON.stringify(bad)], 'p.json')
+    await expect(loadFromFile(file)).rejects.toThrow('Invalid maxGrip value')
+  })
 })
 
 describe('saveToFile', () => {
@@ -49,5 +55,18 @@ describe('saveToFile', () => {
     const text = await blob.text()
     const data = JSON.parse(text)
     expect(data.guiSettings.PPB_VERSION_NO).toBe(PPB_VERSION_NO)
+  })
+
+  test('includes maxGrip fields', async () => {
+    const proj: PalletProject = {
+      ...baseProject,
+      maxGrip: 3,
+      maxGripAuto: true,
+    }
+    const blob = saveToFile(proj)
+    const text = await blob.text()
+    const data = JSON.parse(text)
+    expect(data.maxGrip).toBe(3)
+    expect(data.maxGripAuto).toBe(true)
   })
 })

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -58,7 +58,11 @@ export async function loadFromFile(file: File): Promise<PalletProject> {
   }
 
   if (data.maxGrip !== undefined) {
-    if (typeof data.maxGrip !== 'number' || data.maxGrip < 0) {
+    if (
+      typeof data.maxGrip !== 'number' ||
+      !Number.isInteger(data.maxGrip) ||
+      data.maxGrip < 0
+    ) {
       throw new Error('Invalid maxGrip value')
     }
   }


### PR DESCRIPTION
## Summary
- add fields for `maxGrip` and `maxGripAuto` to the default project
- expose numeric/checkbox inputs for these fields in the React UI
- validate `maxGrip` as a non-negative integer when loading JSON
- persist these fields when saving a project
- extend tests and sample project accordingly

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68513672dd3c8325a2cb4fdbc4d8c896