### PR TITLE
Add pallet validation

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css'
 import { loadFromFile, saveToFile } from './data/jsonIO'
 import type { PalletProject } from './data/interfaces'
 import { PPB_VERSION_NO } from './data/interfaces'
+import { productFits } from './productFit'
 
 const MM_TO_INCH = 25.4
 
@@ -30,6 +31,7 @@ const defaultProject: PalletProject = {
 
 function App() {
   const [project, setProject] = useState<PalletProject>(defaultProject)
+  const fits = productFits(project)
 
   const updateDimensions = (key: keyof typeof project.dimensions, value: number) => {
     setProject((prev) => ({
@@ -214,9 +216,15 @@ function App() {
           {project.dimensions.maxLoadHeight}
         </p>
       </div>
+      {!fits && (
+        <p className="text-red-500 mb-2">
+          Product dimensions exceed pallet size plus allowed overhang
+        </p>
+      )}
       <button
         className="bg-blue-500 text-white px-4 py-2 rounded"
         onClick={handleSave}
+        disabled={!fits}
       >
         Zapisz
       </button>

--- a/pal-in/src/productFit.ts
+++ b/pal-in/src/productFit.ts
@@ -1,0 +1,11 @@
+import type { PalletProject } from './data/interfaces'
+
+export function productFits(project: PalletProject): boolean {
+  const overhang = project.overhang ?? 0
+  const allowedLength = project.dimensions.length + overhang
+  const allowedWidth = project.dimensions.width + overhang
+  return (
+    project.productDimensions.length <= allowedLength &&
+    project.productDimensions.width <= allowedWidth
+  )
+}

--- a/pal-in/src/productFits.test.ts
+++ b/pal-in/src/productFits.test.ts
@@ -1,0 +1,41 @@
+import { productFits } from './productFit'
+import { PPB_VERSION_NO, type PalletProject } from './data/interfaces'
+
+describe('productFits', () => {
+  const base: PalletProject = {
+    name: 'P',
+    dimensions: { length: 100, width: 100, maxLoadHeight: 100, palletHeight: 10 },
+    productDimensions: { length: 50, width: 50, height: 50, weight: 1 },
+    guiSettings: { PPB_VERSION_NO },
+    layerTypes: [],
+    layers: [],
+    overhang: 0,
+  }
+
+  test('fits when within pallet size', () => {
+    expect(productFits(base)).toBe(true)
+  })
+
+  test('fails when too large', () => {
+    const p = { ...base, productDimensions: { ...base.productDimensions, width: 120 } }
+    expect(productFits(p)).toBe(false)
+  })
+
+  test('allows overhang', () => {
+    const p = {
+      ...base,
+      overhang: 20,
+      productDimensions: { ...base.productDimensions, width: 110 },
+    }
+    expect(productFits(p)).toBe(true)
+  })
+
+  test('fails if overhang insufficient', () => {
+    const p = {
+      ...base,
+      overhang: 5,
+      productDimensions: { ...base.productDimensions, length: 110 },
+    }
+    expect(productFits(p)).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- validate product against pallet dimensions plus allowed overhang
- show warning and disable save when product too large
- test validation logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68513674b6548325aac07f75f11136b2