### PR TITLE
Add box padding support

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -23,6 +23,7 @@ const defaultProject: PalletProject = {
   labelOrientation: '0',
   units: 'mm',
   overhang: 0,
+  boxPadding: 0,
   guiSettings: { PPB_VERSION_NO },
   layerTypes: [],
   layers: [],
@@ -65,6 +66,8 @@ function App() {
         height: convert(p.productDimensions.height),
       },
       overhang: p.overhang !== undefined ? convert(p.overhang) : p.overhang,
+      boxPadding:
+        p.boxPadding !== undefined ? convert(p.boxPadding) : p.boxPadding,
     }
   }
 
@@ -75,6 +78,7 @@ function App() {
         const proj = await loadFromFile(file)
         if (!proj.units) proj.units = 'mm'
         if (proj.overhang === undefined) proj.overhang = 0
+        if (proj.boxPadding === undefined) proj.boxPadding = 0
         setProject(proj)
         alert('Loaded project ' + proj.name)
       } catch (err) {
@@ -182,6 +186,17 @@ function App() {
             type="number"
             value={project.productDimensions.weight}
             onChange={(e) => updateProduct('weight', e.target.valueAsNumber)}
+          />
+        </div>
+        <div>
+          <label className="mr-2">Box padding</label>
+          <input
+            className="border"
+            type="number"
+            value={project.boxPadding}
+            onChange={(e) =>
+              setProject((prev) => ({ ...prev, boxPadding: e.target.valueAsNumber }))
+            }
           />
         </div>
         <div>

--- a/pal-in/src/data/interfaces.ts
+++ b/pal-in/src/data/interfaces.ts
@@ -59,6 +59,8 @@ export interface PalletProject {
   units?: 'mm' | 'inch'
   /** product overhang beyond pallet edge */
   overhang?: number
+  /** padding around product boxes used when packing */
+  boxPadding?: number
   guiSettings: GuiSettings
   layerTypes: LayerDefinition[]
   layers: string[]

--- a/pal-in/src/data/jsonIO.test.ts
+++ b/pal-in/src/data/jsonIO.test.ts
@@ -37,6 +37,19 @@ describe('loadFromFile', () => {
     const file = new File([JSON.stringify(bad)], 'p.json')
     await expect(loadFromFile(file)).rejects.toThrow('Pattern item outside pallet bounds')
   })
+
+  test('reads boxPadding value', async () => {
+    const proj = { ...baseProject, boxPadding: 5 }
+    const file = new File([JSON.stringify(proj)], 'p.json')
+    const result = await loadFromFile(file)
+    expect(result.boxPadding).toBe(5)
+  })
+
+  test('rejects negative boxPadding', async () => {
+    const proj = { ...baseProject, boxPadding: -1 }
+    const file = new File([JSON.stringify(proj)], 'p.json')
+    await expect(loadFromFile(file)).rejects.toThrow('Invalid boxPadding value')
+  })
 })
 
 describe('saveToFile', () => {

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -65,6 +65,11 @@ export async function loadFromFile(file: File): Promise<PalletProject> {
   if (data.maxGripAuto !== undefined && typeof data.maxGripAuto !== 'boolean') {
     throw new Error('Invalid maxGripAuto flag')
   }
+  if (data.boxPadding !== undefined) {
+    if (typeof data.boxPadding !== 'number' || data.boxPadding < 0) {
+      throw new Error('Invalid boxPadding value')
+    }
+  }
   if (
     data.labelOrientation !== undefined &&
     !VALID_LABEL_ORIENTATIONS.has(data.labelOrientation)


### PR DESCRIPTION
## Summary
- extend `PalletProject` interface with `boxPadding`
- validate `boxPadding` in JSON loader
- allow converting `boxPadding` when switching units
- display a numeric input for box padding
- test box padding handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68513673881c83259e1cd1c3334d0dad