### PR TITLE
Use enum for label orientation

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import './App.css'
 import { loadFromFile, saveToFile } from './data/jsonIO'
 import type { PalletProject } from './data/interfaces'
-import { PPB_VERSION_NO } from './data/interfaces'
+import { PPB_VERSION_NO, LABEL_ORIENTATIONS } from './data/interfaces'
 import { productFits } from './productFit'
 
 const MM_TO_INCH = 25.4
@@ -21,7 +21,7 @@ const defaultProject: PalletProject = {
     height: 200,
     weight: 1,
   },
-  labelOrientation: '0',
+  labelOrientation: 'front',
   units: 'mm',
   overhangSides: 0,
   overhangEnds: 0,
@@ -221,14 +221,22 @@ function App() {
         </div>
         <div>
           <label className="mr-2">Label orientation</label>
-          <input
+          <select
             className="border"
-            type="text"
             value={project.labelOrientation}
             onChange={(e) =>
-              setProject((prev) => ({ ...prev, labelOrientation: e.target.value }))
+              setProject((prev) => ({
+                ...prev,
+                labelOrientation: e.target.value as (typeof LABEL_ORIENTATIONS)[number],
+              }))
             }
-          />
+          >
+            {LABEL_ORIENTATIONS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
         </div>
       </div>
       <div className="mb-4">

--- a/pal-in/src/data/interfaces.ts
+++ b/pal-in/src/data/interfaces.ts
@@ -47,6 +47,15 @@ export interface GuiSettings {
   [key: string]: unknown
 }
 
+export const LABEL_ORIENTATIONS = [
+  'front',
+  'back',
+  'left',
+  'right',
+  'none',
+] as const
+export type LabelOrientation = typeof LABEL_ORIENTATIONS[number]
+
 export interface PalletProject {
   name: string
   description?: string
@@ -54,7 +63,7 @@ export interface PalletProject {
   productDimensions: ProductDimensions
   maxGrip?: number
   maxGripAuto?: boolean
-  labelOrientation?: string
+  labelOrientation?: LabelOrientation
   /** unit system used for dimensions */
   units?: 'mm' | 'inch'
   /** product overhang beyond pallet sides */

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -1,14 +1,8 @@
-import { PPB_VERSION_NO } from './interfaces'
+import { PPB_VERSION_NO, LABEL_ORIENTATIONS } from './interfaces'
 import type { PalletProject, PatternItem } from './interfaces'
 
 const VALID_LAYER_CLASS = new Set(['layer', 'separator'])
-const VALID_LABEL_ORIENTATIONS = new Set([
-  'front',
-  'back',
-  'left',
-  'right',
-  'none',
-])
+const VALID_LABEL_ORIENTATIONS = new Set(LABEL_ORIENTATIONS)
 const VALID_ALT_LAYOUTS = new Set(['default', 'alternate'])
 
 function validatePattern(


### PR DESCRIPTION
## Summary
- enforce label orientations enum in data interfaces
- validate orientation using this enum
- expose allowed orientations in the app
- default orientation to `front` and use a `<select>` in the UI

## Testing
- `npm test` *(fails: Property 'overhang' does not exist on type 'PalletProject')*
- `npx tsc -p tsconfig.app.json` *(fails: Property 'overhang' does not exist on type 'PalletProject')*

------
https://chatgpt.com/codex/tasks/task_e_68513b3c35f48325b618c695c40ee672