### PR TITLE
Use new overhang fields for sizing

### DIFF
--- a/pal-in/src/productFit.ts
+++ b/pal-in/src/productFit.ts
@@ -1,9 +1,10 @@
 import type { PalletProject } from './data/interfaces'
 
 export function productFits(project: PalletProject): boolean {
-  const overhang = project.overhang ?? 0
-  const allowedLength = project.dimensions.length + overhang
-  const allowedWidth = project.dimensions.width + overhang
+  const overhangSides = project.overhangSides ?? 0
+  const overhangEnds = project.overhangEnds ?? 0
+  const allowedLength = project.dimensions.length + overhangEnds
+  const allowedWidth = project.dimensions.width + overhangSides
   return (
     project.productDimensions.length <= allowedLength &&
     project.productDimensions.width <= allowedWidth

--- a/pal-in/src/productFits.test.ts
+++ b/pal-in/src/productFits.test.ts
@@ -9,7 +9,8 @@ describe('productFits', () => {
     guiSettings: { PPB_VERSION_NO },
     layerTypes: [],
     layers: [],
-    overhang: 0,
+    overhangSides: 0,
+    overhangEnds: 0,
   }
 
   test('fits when within pallet size', () => {
@@ -24,7 +25,7 @@ describe('productFits', () => {
   test('allows overhang', () => {
     const p = {
       ...base,
-      overhang: 20,
+      overhangSides: 20,
       productDimensions: { ...base.productDimensions, width: 110 },
     }
     expect(productFits(p)).toBe(true)
@@ -33,7 +34,7 @@ describe('productFits', () => {
   test('fails if overhang insufficient', () => {
     const p = {
       ...base,
-      overhang: 5,
+      overhangEnds: 5,
       productDimensions: { ...base.productDimensions, length: 110 },
     }
     expect(productFits(p)).toBe(false)


### PR DESCRIPTION
## Summary
- update productFit calculation to use separate side and end overhang values
- adjust productFits tests to supply the new fields

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68513b4b23ec8325883f5bfb4008f013