### PR TITLE
Add pallet layer editing UI

### DIFF
--- a/pal-in/src/LayerList.tsx
+++ b/pal-in/src/LayerList.tsx
@@ -1,0 +1,28 @@
+import React from 'react'
+
+interface LayerListProps {
+  layers: string[]
+  onSelect: (index: number) => void
+  selected: number | null
+  moveUp: (index: number) => void
+  moveDown: (index: number) => void
+}
+
+export default function LayerList({ layers, onSelect, selected, moveUp, moveDown }: LayerListProps) {
+  return (
+    <div className="flex flex-col gap-1">
+      {layers.map((name, idx) => (
+        <div key={idx} className="flex items-center gap-1">
+          <button className="border px-1" onClick={() => moveUp(idx)} disabled={idx===0}>↑</button>
+          <button className="border px-1" onClick={() => moveDown(idx)} disabled={idx===layers.length-1}>↓</button>
+          <button
+            className={`flex-1 text-left border px-2 ${selected===idx ? 'bg-blue-200' : ''}`}
+            onClick={() => onSelect(idx)}
+          >
+            {name}
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/pal-in/src/PatternEditor.tsx
+++ b/pal-in/src/PatternEditor.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import type { LayerDefinition, PatternItem } from './data/interfaces'
+
+interface Props {
+  layer: LayerDefinition
+  onChange: (layer: LayerDefinition) => void
+}
+
+const stringify = (p?: PatternItem[]) => (p ? JSON.stringify(p, null, 2) : '')
+
+export default function PatternEditor({ layer, onChange }: Props) {
+  const [patternText, setPatternText] = useState(stringify(layer.pattern))
+  const [altText, setAltText] = useState(stringify(layer.altPattern))
+
+  const applyChanges = () => {
+    try {
+      const newLayer: LayerDefinition = {
+        ...layer,
+        pattern: patternText ? JSON.parse(patternText) : undefined,
+        altPattern: altText ? JSON.parse(altText) : undefined,
+      }
+      onChange(newLayer)
+    } catch {
+      alert('Invalid JSON')
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <textarea
+        className="border p-1 font-mono text-sm"
+        rows={4}
+        value={patternText}
+        onChange={(e) => setPatternText(e.target.value)}
+        placeholder="Pattern JSON"
+      />
+      <textarea
+        className="border p-1 font-mono text-sm"
+        rows={4}
+        value={altText}
+        onChange={(e) => setAltText(e.target.value)}
+        placeholder="Alt Pattern JSON"
+      />
+      <button className="bg-blue-500 text-white px-2 py-1" onClick={applyChanges}>
+        Apply
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create `LayerList` and `PatternEditor` React components
- update `App.tsx` with layer management logic
- allow adding/removing/reordering layers and editing their patterns via new UI

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851429c60d4832584131ab5c07df162