### PR TITLE
Add mirror layout support

### DIFF
--- a/pal-in/src/data/interfaces.ts
+++ b/pal-in/src/data/interfaces.ts
@@ -43,9 +43,11 @@ export interface LayerDefinition {
   altApproach?: string
 }
 
+export type AltLayout = 'default' | 'alternate' | 'mirror'
+
 export interface GuiSettings {
   PPB_VERSION_NO: string
-  altLayout?: string
+  altLayout?: AltLayout
   [key: string]: unknown
 }
 

--- a/pal-in/src/data/jsonIO.test.ts
+++ b/pal-in/src/data/jsonIO.test.ts
@@ -27,6 +27,16 @@ describe('loadFromFile', () => {
     expect(result.productDimensions.boxPadding).toBe(0)
   })
 
+  test('accepts mirror altLayout', async () => {
+    const proj = {
+      ...baseProject,
+      guiSettings: { ...baseProject.guiSettings, altLayout: 'mirror' },
+    }
+    const file = new File([JSON.stringify(proj)], 'p.json')
+    const result = await loadFromFile(file)
+    expect(result.guiSettings.altLayout).toBe('mirror')
+  })
+
   test('rejects unsupported version', async () => {
     const bad = { ...baseProject, guiSettings: { PPB_VERSION_NO: '0.0.0' } }
     const file = new File([JSON.stringify(bad)], 'p.json')

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -3,7 +3,7 @@ import type { PalletProject, PatternItem } from './interfaces'
 
 const VALID_LAYER_CLASS = new Set(['layer', 'separator'])
 const VALID_LABEL_ORIENTATIONS = new Set(LABEL_ORIENTATIONS)
-const VALID_ALT_LAYOUTS = new Set(['default', 'alternate'])
+const VALID_ALT_LAYOUTS = new Set(['default', 'alternate', 'mirror'])
 
 function validatePattern(
   pattern: PatternItem[] | undefined,


### PR DESCRIPTION
## Summary
- allow mirror alt layout in GUI settings
- update list of valid alt layouts
- test that altLayout "mirror" is loaded correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685142a644bc83259b4db6c91eea605f