### PR TITLE
Support array rotations in JSON patterns

### DIFF
--- a/pal-in/src/data/interfaces.ts
+++ b/pal-in/src/data/interfaces.ts
@@ -26,7 +26,7 @@ export interface PatternItem {
   /** y position on the pallet */
   y: number
   /** rotation */
-  r: number
+  r: number | number[]
   /** optional grouping id */
   g?: number
   /** optional flip/index */

--- a/pal-in/src/data/jsonIO.test.ts
+++ b/pal-in/src/data/jsonIO.test.ts
@@ -18,6 +18,13 @@ const baseProject: PalletProject = {
   layers: ['layer1'],
 }
 
+const arrayRotProject: PalletProject = {
+  ...baseProject,
+  layerTypes: [
+    { name: 'layer1', class: 'layer', pattern: [{ x: 0, y: 0, r: [0, 90] }] },
+  ],
+}
+
 describe('loadFromFile', () => {
   test('parses valid project', async () => {
     const file = new File([JSON.stringify(baseProject)], 'p.json')
@@ -25,6 +32,14 @@ describe('loadFromFile', () => {
     expect(result.name).toBe('Test Project')
     expect(result.guiSettings.PPB_VERSION_NO).toBe(PPB_VERSION_NO)
     expect(result.productDimensions.boxPadding).toBe(0)
+  })
+
+  test('parses project with rotation array', async () => {
+    const file = new File([JSON.stringify(arrayRotProject)], 'p.json')
+    const result = await loadFromFile(file)
+    const item = result.layerTypes[0].pattern![0]
+    expect(Array.isArray(item.r)).toBe(true)
+    expect(item.r).toEqual([0, 90])
   })
 
   test('rejects unsupported version', async () => {
@@ -43,6 +58,18 @@ describe('loadFromFile', () => {
     }
     const file = new File([JSON.stringify(bad)], 'p.json')
     await expect(loadFromFile(file)).rejects.toThrow('Pattern item outside pallet bounds')
+  })
+
+  test('rejects invalid rotation', async () => {
+    const bad = {
+      ...baseProject,
+      layerTypes: [
+        { name: 'l', class: 'layer', pattern: [{ x: 0, y: 0, r: 400 }] },
+      ],
+      layers: ['l'],
+    }
+    const file = new File([JSON.stringify(bad)], 'p.json')
+    await expect(loadFromFile(file)).rejects.toThrow('Invalid rotation value')
   })
 
   test('rejects invalid boxPadding', async () => {

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -20,6 +20,13 @@ function validatePattern(
     ) {
       throw new Error('Pattern item outside pallet bounds')
     }
+
+    const rotations = Array.isArray(item.r) ? item.r : [item.r]
+    for (const rot of rotations) {
+      if (typeof rot !== 'number' || rot < 0 || rot >= 360) {
+        throw new Error('Invalid rotation value')
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
- allow `PatternItem.r` to be a number or an array
- validate all rotation values when loading JSON
- add tests for array rotations and invalid rotations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685142a797988325b732f377ad106216