### PR TITLE
Show layer classes

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -346,6 +346,7 @@ function App() {
       <div className="mb-4 max-w-md mx-auto">
         <LayerList
           layers={project.layers}
+          layerDefs={Object.fromEntries(project.layerTypes.map((lt) => [lt.name, lt]))}
           onSelect={setSelectedLayer}
           selected={selectedLayer}
           moveUp={moveLayerUp}

--- a/pal-in/src/LayerList.tsx
+++ b/pal-in/src/LayerList.tsx
@@ -1,28 +1,46 @@
 import React from 'react'
+import type { LayerDefinition } from './data/interfaces'
 
 interface LayerListProps {
   layers: string[]
+  layerDefs: Record<string, LayerDefinition>
   onSelect: (index: number) => void
   selected: number | null
   moveUp: (index: number) => void
   moveDown: (index: number) => void
 }
 
-export default function LayerList({ layers, onSelect, selected, moveUp, moveDown }: LayerListProps) {
+export default function LayerList({
+  layers,
+  layerDefs,
+  onSelect,
+  selected,
+  moveUp,
+  moveDown,
+}: LayerListProps) {
   return (
     <div className="flex flex-col gap-1">
-      {layers.map((name, idx) => (
-        <div key={idx} className="flex items-center gap-1">
-          <button className="border px-1" onClick={() => moveUp(idx)} disabled={idx===0}>↑</button>
-          <button className="border px-1" onClick={() => moveDown(idx)} disabled={idx===layers.length-1}>↓</button>
-          <button
-            className={`flex-1 text-left border px-2 ${selected===idx ? 'bg-blue-200' : ''}`}
-            onClick={() => onSelect(idx)}
-          >
-            {name}
-          </button>
-        </div>
-      ))}
+      {layers.map((name, idx) => {
+        const def = layerDefs[name]
+        const isSep = def?.class === 'separator'
+        return (
+          <div key={idx} className="flex items-center gap-1">
+            <button className="border px-1" onClick={() => moveUp(idx)} disabled={idx===0}>↑</button>
+            <button className="border px-1" onClick={() => moveDown(idx)} disabled={idx===layers.length-1}>↓</button>
+            <button
+              className={`flex-1 text-left border px-2 flex items-center ${selected===idx ? 'bg-blue-200' : ''} ${isSep ? 'bg-gray-100 italic' : ''}`}
+              onClick={() => onSelect(idx)}
+            >
+              {def?.class === 'separator' ? (
+                <span className="inline-block w-3 border-t border-gray-600 mr-1" />
+              ) : (
+                <span className="inline-block w-3 h-3 bg-gray-600 mr-1" />
+              )}
+              {name}
+            </button>
+          </div>
+        )
+      })}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- extend `LayerList` props with `layerDefs` map
- show icon for each layer's class and style separators
- pass layer definitions when rendering `LayerList`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68516ef848908325bc409e6af0bc8469