### PR TITLE
Add layer type selection

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -134,6 +134,21 @@ function App() {
     setSelectedLayer((sel) => (sel === index ? index + 1 : sel === index + 1 ? index : sel))
   }
 
+  const changeLayerRef = (index: number, name: string) => {
+    setProject((prev) => {
+      const currentType = prev.layerTypes.find((lt) => lt.name === prev.layers[index])
+      const newType = prev.layerTypes.find((lt) => lt.name === name)
+      if (currentType && newType && currentType.class !== newType.class) {
+        if (!confirm('Switching between layer and separator types may be incompatible. Continue?')) {
+          return prev
+        }
+      }
+      const arr = [...prev.layers]
+      arr[index] = name
+      return { ...prev, layers: arr }
+    })
+  }
+
   const updateLayerDef = (index: number, layer: LayerDefinition) => {
     setProject((prev) => {
       const types = prev.layerTypes.map((lt) => (lt.name === prev.layers[index] ? layer : lt))
@@ -346,7 +361,9 @@ function App() {
       <div className="mb-4 max-w-md mx-auto">
         <LayerList
           layers={project.layers}
+          types={project.layerTypes.map((lt) => lt.name)}
           onSelect={setSelectedLayer}
+          onChange={changeLayerRef}
           selected={selectedLayer}
           moveUp={moveLayerUp}
           moveDown={moveLayerDown}

--- a/pal-in/src/LayerList.tsx
+++ b/pal-in/src/LayerList.tsx
@@ -2,25 +2,43 @@ import React from 'react'
 
 interface LayerListProps {
   layers: string[]
+  /** all available layer type names */
+  types: string[]
   onSelect: (index: number) => void
+  /** update the layer reference when a new type is chosen */
+  onChange: (index: number, name: string) => void
   selected: number | null
   moveUp: (index: number) => void
   moveDown: (index: number) => void
 }
 
-export default function LayerList({ layers, onSelect, selected, moveUp, moveDown }: LayerListProps) {
+export default function LayerList({
+  layers,
+  types,
+  onSelect,
+  onChange,
+  selected,
+  moveUp,
+  moveDown,
+}: LayerListProps) {
   return (
     <div className="flex flex-col gap-1">
       {layers.map((name, idx) => (
         <div key={idx} className="flex items-center gap-1">
           <button className="border px-1" onClick={() => moveUp(idx)} disabled={idx===0}>↑</button>
           <button className="border px-1" onClick={() => moveDown(idx)} disabled={idx===layers.length-1}>↓</button>
-          <button
-            className={`flex-1 text-left border px-2 ${selected===idx ? 'bg-blue-200' : ''}`}
+          <select
+            className={`flex-1 border px-2 ${selected===idx ? 'bg-blue-200' : ''}`}
+            value={name}
+            onChange={(e) => onChange(idx, e.target.value)}
             onClick={() => onSelect(idx)}
           >
-            {name}
-          </button>
+            {types.map((t) => (
+              <option key={t} value={t}>
+                {t}
+              </option>
+            ))}
+          </select>
         </div>
       ))}
     </div>


### PR DESCRIPTION
## Summary
- allow choosing layer type with a select dropdown
- sync layer changes back to project in App
- warn if switching between layer and separator types

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68516efa2bfc8325bf062f5aee97fc5f