### PR TITLE
Enable drag-and-drop pattern editor

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -370,6 +370,8 @@ function App() {
                   (l) => l.name === project.layers[selectedLayer],
                 )!
               }
+              dims={project.dimensions}
+              product={project.productDimensions}
               onChange={(layer) => updateLayerDef(selectedLayer, layer)}
             />
           </div>

--- a/pal-in/src/PatternEditor.tsx
+++ b/pal-in/src/PatternEditor.tsx
@@ -1,49 +1,156 @@
-import React, { useState } from 'react'
-import type { LayerDefinition, PatternItem } from './data/interfaces'
+import React, { useEffect, useRef, useState } from 'react'
+import type {
+  LayerDefinition,
+  PatternItem,
+  Dimensions,
+  ProductDimensions,
+} from './data/interfaces'
 
 interface Props {
   layer: LayerDefinition
+  dims: Dimensions
+  product: ProductDimensions
   onChange: (layer: LayerDefinition) => void
 }
 
-const stringify = (p?: PatternItem[]) => (p ? JSON.stringify(p, null, 2) : '')
+export default function PatternEditor({ layer, dims, product, onChange }: Props) {
+  const [items, setItems] = useState<PatternItem[]>(layer.pattern ?? [])
+  const [selected, setSelected] = useState<number | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
 
-export default function PatternEditor({ layer, onChange }: Props) {
-  const [patternText, setPatternText] = useState(stringify(layer.pattern))
-  const [altText, setAltText] = useState(stringify(layer.altPattern))
+  // pixels per unit
+  const SCALE = 300 / Math.max(dims.length, dims.width)
+  const boxW = product.width * SCALE
+  const boxH = product.length * SCALE
 
-  const applyChanges = () => {
-    try {
-      const newLayer: LayerDefinition = {
-        ...layer,
-        pattern: patternText ? JSON.parse(patternText) : undefined,
-        altPattern: altText ? JSON.parse(altText) : undefined,
+  useEffect(() => {
+    setItems(layer.pattern ?? [])
+  }, [layer.pattern])
+
+  useEffect(() => {
+    onChange({ ...layer, pattern: items })
+  }, [items])
+
+  // Keyboard handlers for selected item
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (selected === null) return
+      if (e.key === 'r') {
+        setItems((arr) => {
+          const copy = [...arr]
+          const it = copy[selected]
+          copy[selected] = { ...it, r: ((it.r ?? 0) + 90) % 360 }
+          return copy
+        })
+      } else if (e.key === 'f') {
+        setItems((arr) => {
+          const copy = [...arr]
+          const it = copy[selected]
+          copy[selected] = { ...it, f: it.f === 1 ? 2 : 1 }
+          return copy
+        })
+      } else if (e.key === 'Delete' || e.key === 'Backspace') {
+        setItems((arr) => arr.filter((_, i) => i !== selected))
+        setSelected(null)
       }
-      onChange(newLayer)
-    } catch {
-      alert('Invalid JSON')
     }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [selected])
+
+  const handleContainerClick = (e: React.MouseEvent) => {
+    if (e.target !== containerRef.current) return
+    const rect = containerRef.current!.getBoundingClientRect()
+    const x = (e.clientX - rect.left) / SCALE
+    const y = (e.clientY - rect.top) / SCALE
+    const newItem: PatternItem = { x, y, r: 0, f: 1 }
+    setItems((arr) => [...arr, newItem])
+  }
+
+  // dragging helpers
+  const dragData = useRef<{
+    index: number
+    startX: number
+    startY: number
+    itemX: number
+    itemY: number
+  } | null>(null)
+
+  const onMouseMove = (e: MouseEvent) => {
+    if (!dragData.current) return
+    e.preventDefault()
+    const { index, startX, startY, itemX, itemY } = dragData.current
+    const dx = (e.clientX - startX) / SCALE
+    const dy = (e.clientY - startY) / SCALE
+    setItems((arr) => {
+      const copy = [...arr]
+      copy[index] = { ...copy[index], x: itemX + dx, y: itemY + dy }
+      return copy
+    })
+  }
+
+  const endDrag = () => {
+    dragData.current = null
+    window.removeEventListener('mousemove', onMouseMove)
+    window.removeEventListener('mouseup', endDrag)
+  }
+
+  const startDrag = (index: number, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setSelected(index)
+    dragData.current = {
+      index,
+      startX: e.clientX,
+      startY: e.clientY,
+      itemX: items[index].x,
+      itemY: items[index].y,
+    }
+    window.addEventListener('mousemove', onMouseMove)
+    window.addEventListener('mouseup', endDrag)
   }
 
   return (
     <div className="flex flex-col gap-2">
-      <textarea
-        className="border p-1 font-mono text-sm"
-        rows={4}
-        value={patternText}
-        onChange={(e) => setPatternText(e.target.value)}
-        placeholder="Pattern JSON"
-      />
-      <textarea
-        className="border p-1 font-mono text-sm"
-        rows={4}
-        value={altText}
-        onChange={(e) => setAltText(e.target.value)}
-        placeholder="Alt Pattern JSON"
-      />
-      <button className="bg-blue-500 text-white px-2 py-1" onClick={applyChanges}>
-        Apply
+      <div
+        ref={containerRef}
+        onClick={handleContainerClick}
+        className="relative border bg-gray-100 mx-auto"
+        style={{ width: dims.width * SCALE, height: dims.length * SCALE }}
+      >
+        {items.map((item, idx) => {
+          const style: React.CSSProperties = {
+            position: 'absolute',
+            left: item.x * SCALE,
+            top: item.y * SCALE,
+            width: boxW,
+            height: boxH,
+            background: 'rgba(59,130,246,0.3)',
+            border: selected === idx ? '2px solid red' : '1px solid blue',
+            boxSizing: 'border-box',
+            transform: `rotate(${item.r}deg)`,
+            cursor: 'move',
+          }
+          return (
+            <div
+              key={idx}
+              style={style}
+              onMouseDown={(e) => startDrag(idx, e)}
+            />
+          )
+        })}
+      </div>
+      <button
+        className="bg-red-500 text-white px-2 py-1"
+        onClick={() => {
+          if (selected !== null) {
+            setItems((arr) => arr.filter((_, i) => i !== selected))
+            setSelected(null)
+          }
+        }}
+      >
+        Delete Selected
       </button>
     </div>
   )
 }
+


### PR DESCRIPTION
## Summary
- implement a grid based `PatternEditor` with draggable boxes
- update selected boxes with keyboard shortcuts (rotate, flip and delete)
- wire PatternEditor up to pallet and product dimensions

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68516eff7ad0832583065a5073285d57