### PR TITLE
Add default separator layer and height handling

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -31,7 +31,13 @@ const defaultProject: PalletProject = {
   maxGrip: 0,
   maxGripAuto: false,
   guiSettings: { PPB_VERSION_NO },
-  layerTypes: [],
+  layerTypes: [
+    {
+      name: 'shim',
+      class: 'separator',
+      height: 1,
+    },
+  ],
   layers: [],
 }
 
@@ -153,6 +159,11 @@ function App() {
           proj.productDimensions.boxPadding = 0
         if (proj.maxGrip === undefined) proj.maxGrip = 0
         if (proj.maxGripAuto === undefined) proj.maxGripAuto = false
+        for (const lt of proj.layerTypes) {
+          if (lt.class === 'separator' && lt.height === undefined) {
+            lt.height = 1
+          }
+        }
         setProject(proj)
         alert('Loaded project ' + proj.name)
       } catch (err) {

--- a/pal-in/src/data/jsonIO.test.ts
+++ b/pal-in/src/data/jsonIO.test.ts
@@ -63,6 +63,46 @@ describe('loadFromFile', () => {
     const file = new File([JSON.stringify(bad)], 'p.json')
     await expect(loadFromFile(file)).rejects.toThrow('Invalid boxPadding value')
   })
+
+  test('allows separator layer with height', async () => {
+    const proj: PalletProject = {
+      ...baseProject,
+      layerTypes: [
+        { name: 'shim', class: 'separator', height: 2 },
+        ...baseProject.layerTypes,
+      ],
+    }
+    const file = new File([JSON.stringify(proj)], 'p.json')
+    const result = await loadFromFile(file)
+    const shim = result.layerTypes.find((lt) => lt.name === 'shim')!
+    expect(shim.height).toBe(2)
+  })
+
+  test('defaults separator height when missing', async () => {
+    const proj: PalletProject = {
+      ...baseProject,
+      layerTypes: [
+        { name: 'shim', class: 'separator' },
+        ...baseProject.layerTypes,
+      ],
+    }
+    const file = new File([JSON.stringify(proj)], 'p.json')
+    const result = await loadFromFile(file)
+    const shim = result.layerTypes.find((lt) => lt.name === 'shim')!
+    expect(shim.height).toBe(1)
+  })
+
+  test('rejects negative separator height', async () => {
+    const proj: PalletProject = {
+      ...baseProject,
+      layerTypes: [
+        { name: 'shim', class: 'separator', height: -1 },
+        ...baseProject.layerTypes,
+      ],
+    }
+    const file = new File([JSON.stringify(proj)], 'p.json')
+    await expect(loadFromFile(file)).rejects.toThrow('Invalid layer height')
+  })
 })
 
 describe('saveToFile', () => {

--- a/pal-in/src/data/jsonIO.ts
+++ b/pal-in/src/data/jsonIO.ts
@@ -106,6 +106,9 @@ export async function loadFromFile(file: File): Promise<PalletProject> {
     if (!VALID_LAYER_CLASS.has(lt.class)) {
       throw new Error('Invalid layer class: ' + lt.class)
     }
+    if (lt.class === 'separator' && lt.height === undefined) {
+      lt.height = 1
+    }
     if (lt.height !== undefined && lt.height < 0) {
       throw new Error('Invalid layer height')
     }


### PR DESCRIPTION
## Summary
- include a default `separator` layer when new projects are created
- keep separator validation in jsonIO while defaulting missing heights
- load default height from files that omit the field
- test separator parsing logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68516f0195708325a0b0513570451930