### PR TITLE
Add alt layout setting and mirrored pattern logic

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -2,12 +2,17 @@ import { useState } from 'react'
 import './App.css'
 import { loadFromFile, saveToFile } from './data/jsonIO'
 import type { PalletProject, LayerDefinition } from './data/interfaces'
-import { PPB_VERSION_NO, LABEL_ORIENTATIONS } from './data/interfaces'
+import {
+  PPB_VERSION_NO,
+  LABEL_ORIENTATIONS,
+  type AltLayout,
+} from './data/interfaces'
 import { productFits } from './productFit'
 import LayerList from './LayerList'
 import PatternEditor from './PatternEditor'
 
 const MM_TO_INCH = 25.4
+const ALT_LAYOUTS: AltLayout[] = ['default', 'alternate', 'mirror']
 
 const defaultProject: PalletProject = {
   name: 'New Project',
@@ -319,6 +324,28 @@ function App() {
           </select>
         </div>
         <div>
+          <label className="mr-2">Alt layout</label>
+          <select
+            className="border"
+            value={project.guiSettings.altLayout ?? 'default'}
+            onChange={(e) =>
+              setProject((prev) => ({
+                ...prev,
+                guiSettings: {
+                  ...prev.guiSettings,
+                  altLayout: e.target.value as AltLayout,
+                },
+              }))
+            }
+          >
+            {ALT_LAYOUTS.map((opt) => (
+              <option key={opt} value={opt}>
+                {opt}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
           <label className="mr-2">Max grip</label>
           <input
             className="border"
@@ -370,6 +397,9 @@ function App() {
                   (l) => l.name === project.layers[selectedLayer],
                 )!
               }
+              altLayout={project.guiSettings.altLayout ?? 'default'}
+              dimensions={project.dimensions}
+              productDimensions={project.productDimensions}
               onChange={(layer) => updateLayerDef(selectedLayer, layer)}
             />
           </div>

--- a/pal-in/src/PatternEditor.tsx
+++ b/pal-in/src/PatternEditor.tsx
@@ -1,23 +1,55 @@
 import React, { useState } from 'react'
-import type { LayerDefinition, PatternItem } from './data/interfaces'
+import type {
+  LayerDefinition,
+  PatternItem,
+  AltLayout,
+  Dimensions,
+  ProductDimensions,
+} from './data/interfaces'
 
 interface Props {
   layer: LayerDefinition
+  altLayout: AltLayout
+  dimensions: Dimensions
+  productDimensions: ProductDimensions
   onChange: (layer: LayerDefinition) => void
 }
 
 const stringify = (p?: PatternItem[]) => (p ? JSON.stringify(p, null, 2) : '')
 
-export default function PatternEditor({ layer, onChange }: Props) {
+function mirrorPattern(
+  pattern: PatternItem[],
+  palletWidth: number,
+  itemWidth: number,
+) {
+  return pattern.map((it) => ({
+    ...it,
+    x: palletWidth - itemWidth - it.x,
+  }))
+}
+
+export default function PatternEditor({
+  layer,
+  altLayout,
+  dimensions,
+  productDimensions,
+  onChange,
+}: Props) {
   const [patternText, setPatternText] = useState(stringify(layer.pattern))
   const [altText, setAltText] = useState(stringify(layer.altPattern))
 
   const applyChanges = () => {
     try {
+      const parsedPattern = patternText ? JSON.parse(patternText) : undefined
+      const altPattern = altText
+        ? JSON.parse(altText)
+        : altLayout === 'mirror' && parsedPattern
+        ? mirrorPattern(parsedPattern, dimensions.width, productDimensions.width)
+        : undefined
       const newLayer: LayerDefinition = {
         ...layer,
-        pattern: patternText ? JSON.parse(patternText) : undefined,
-        altPattern: altText ? JSON.parse(altText) : undefined,
+        pattern: parsedPattern,
+        altPattern,
       }
       onChange(newLayer)
     } catch {


### PR DESCRIPTION
## Summary
- add list of available alt layouts in App and GUI
- allow editing `project.guiSettings.altLayout`
- compute default alt pattern using mirrored layout
- update PatternEditor props for alt layout settings

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68516f03e5c08325b4ff92d264fe9528