### PR TITLE
Add drag-and-drop reordering to layer list

### DIFF
--- a/pal-in/package-lock.json
+++ b/pal-in/package-lock.json
@@ -7,9 +7,11 @@
     "": {
       "name": "pal-in",
       "version": "0.0.0",
+      "license": "MIT",
       "dependencies": {
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-sortablejs": "^6.1.4"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2964,6 +2966,13 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@types/sortablejs": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/sortablejs/-/sortablejs-1.15.8.tgz",
+      "integrity": "sha512-b79830lW+RZfwaztgs1aVPgbasJ8e7AXtZYHTELNXZPsERt4ymJdjV4OccDbHQAvHrCcFpbF78jkm0R6h/pZVg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -3997,6 +4006,12 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.1.0.tgz",
       "integrity": "sha512-UX0OwmYRYQQetfrLEZeewIFFI+wSTofC+pMBLNuH3RUuu/xzG1oz84UCEDOSoQlN3fZ4+AzmV50ZYvGqkMh9yA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/classnames": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",
+      "integrity": "sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==",
       "license": "MIT"
     },
     "node_modules/cliui": {
@@ -6986,6 +7001,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-sortablejs": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/react-sortablejs/-/react-sortablejs-6.1.4.tgz",
+      "integrity": "sha512-fc7cBosfhnbh53Mbm6a45W+F735jwZ1UFIYSrIqcO/gRIFoDyZeMtgKlpV4DdyQfbCzdh5LoALLTDRxhMpTyXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "2.3.1",
+        "tiny-invariant": "1.2.0"
+      },
+      "peerDependencies": {
+        "@types/sortablejs": "1",
+        "react": ">=16.9.0",
+        "react-dom": ">=16.9.0",
+        "sortablejs": "1"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -7172,6 +7203,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/sortablejs": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.6.tgz",
+      "integrity": "sha512-aNfiuwMEpfBM/CN6LY0ibyhxPfPbyFeBTYJKCvzkJ2GkUpazIt3H+QIPAMHwqQ7tMKaHz1Qj+rJJCqljnf4p3A==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -7518,6 +7556,12 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/tiny-invariant": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.2.0.tgz",
+      "integrity": "sha512-1Uhn/aqw5C6RI4KejVeTg6mIS7IqxnLJ8Mv2tV5rTc0qWobay7pDUz6Wi392Cnc8ak1H0F2cjoRzb2/AW4+Fvg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/pal-in/package.json
+++ b/pal-in/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-sortablejs": "^6.1.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",
@@ -37,4 +38,3 @@
   },
   "license": "MIT"
 }
-

--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -114,25 +114,26 @@ function App() {
     setSelectedLayer(null)
   }
 
-  const moveLayerUp = (index: number) => {
-    if (index === 0) return
+  const moveLayer = (from: number, to: number) => {
     setProject((prev) => {
       const arr = [...prev.layers]
-      ;[arr[index - 1], arr[index]] = [arr[index], arr[index - 1]]
+      if (from < 0 || from >= arr.length || to < 0 || to >= arr.length) return prev
+      const [item] = arr.splice(from, 1)
+      arr.splice(to, 0, item)
       return { ...prev, layers: arr }
     })
-    setSelectedLayer((sel) => (sel === index ? index - 1 : sel === index - 1 ? index : sel))
+    setSelectedLayer((sel) => {
+      if (sel === null) return sel
+      if (sel === from) return to
+      if (sel > from && sel <= to) return sel - 1
+      if (sel < from && sel >= to) return sel + 1
+      return sel
+    })
   }
 
-  const moveLayerDown = (index: number) => {
-    if (index === project.layers.length - 1) return
-    setProject((prev) => {
-      const arr = [...prev.layers]
-      ;[arr[index + 1], arr[index]] = [arr[index], arr[index + 1]]
-      return { ...prev, layers: arr }
-    })
-    setSelectedLayer((sel) => (sel === index ? index + 1 : sel === index + 1 ? index : sel))
-  }
+  const moveLayerUp = (index: number) => moveLayer(index, index - 1)
+
+  const moveLayerDown = (index: number) => moveLayer(index, index + 1)
 
   const updateLayerDef = (index: number, layer: LayerDefinition) => {
     setProject((prev) => {
@@ -350,6 +351,7 @@ function App() {
           selected={selectedLayer}
           moveUp={moveLayerUp}
           moveDown={moveLayerDown}
+          reorder={moveLayer}
         />
         <div className="mt-2 flex gap-2">
           <button className="border px-2 py-1" onClick={addLayer}>Add</button>

--- a/pal-in/src/LayerList.tsx
+++ b/pal-in/src/LayerList.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import { ReactSortable } from 'react-sortablejs'
 
 interface LayerListProps {
   layers: string[]
@@ -6,23 +6,34 @@ interface LayerListProps {
   selected: number | null
   moveUp: (index: number) => void
   moveDown: (index: number) => void
+  reorder: (from: number, to: number) => void
 }
 
-export default function LayerList({ layers, onSelect, selected, moveUp, moveDown }: LayerListProps) {
+export default function LayerList({ layers, onSelect, selected, moveUp, moveDown, reorder }: LayerListProps) {
+  const items = layers.map((name, id) => ({ id, name }))
+
   return (
-    <div className="flex flex-col gap-1">
-      {layers.map((name, idx) => (
-        <div key={idx} className="flex items-center gap-1">
+    <ReactSortable
+      list={items}
+      setList={() => {}}
+      onEnd={(evt) => {
+        if (evt.oldIndex !== undefined && evt.newIndex !== undefined) {
+          reorder(evt.oldIndex, evt.newIndex)
+        }
+      }}
+    >
+      {items.map((item, idx) => (
+        <div key={item.id} className="flex items-center gap-1">
           <button className="border px-1" onClick={() => moveUp(idx)} disabled={idx===0}>↑</button>
-          <button className="border px-1" onClick={() => moveDown(idx)} disabled={idx===layers.length-1}>↓</button>
+          <button className="border px-1" onClick={() => moveDown(idx)} disabled={idx===items.length-1}>↓</button>
           <button
             className={`flex-1 text-left border px-2 ${selected===idx ? 'bg-blue-200' : ''}`}
             onClick={() => onSelect(idx)}
           >
-            {name}
+            {item.name}
           </button>
         </div>
       ))}
-    </div>
+    </ReactSortable>
   )
 }

--- a/pal-in/src/PatternEditor.tsx
+++ b/pal-in/src/PatternEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import { useState } from 'react'
 import type { LayerDefinition, PatternItem } from './data/interfaces'
 
 interface Props {


### PR DESCRIPTION
## Summary
- integrate `react-sortablejs` and add drag handle to LayerList
- update layer move logic to support arbitrary indices
- keep arrow buttons for keyboard control

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68516efb93948325b2c18d550275039e