### PR TITLE
Add interactive pattern editor

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -370,6 +370,7 @@ function App() {
                   (l) => l.name === project.layers[selectedLayer],
                 )!
               }
+              project={project}
               onChange={(layer) => updateLayerDef(selectedLayer, layer)}
             />
           </div>

--- a/pal-in/src/LayerList.tsx
+++ b/pal-in/src/LayerList.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 
 interface LayerListProps {
   layers: string[]


### PR DESCRIPTION
## Summary
- replace textarea PatternEditor with SVG grid
- allow dragging pattern items within pallet bounds
- update App to pass project info into PatternEditor
- remove unused React import

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68516efdb43c8325b33c689698739787