### PR TITLE
Support editing alt patterns

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -384,6 +384,7 @@ function App() {
               }
               dims={project.dimensions}
               product={project.productDimensions}
+              altLayout={project.guiSettings.altLayout}
               onChange={(layer) => updateLayerDef(selectedLayer, layer)}
             />
           </div>


### PR DESCRIPTION
## Summary
- allow selecting primary or alternate pattern in `PatternEditor`
- auto-generate alternate pattern using project `altLayout`
- connect `PatternEditor` to project's `altLayout`

## Testing
- `npm test`
- `npm run build` *(fails: React unused import)*

------
https://chatgpt.com/codex/tasks/task_e_6851732f38948325b6571ca0a790147d