### PR TITLE
Add overhang limits to PatternEditor

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -384,6 +384,16 @@ function App() {
               }
               dims={project.dimensions}
               product={project.productDimensions}
+              overhangSides={
+                project.overhangSides !== undefined
+                  ? project.overhangSides
+                  : project.overhang ?? 0
+              }
+              overhangEnds={
+                project.overhangEnds !== undefined
+                  ? project.overhangEnds
+                  : project.overhang ?? 0
+              }
               onChange={(layer) => updateLayerDef(selectedLayer, layer)}
             />
           </div>

--- a/pal-in/src/data/jsonIO.test.ts
+++ b/pal-in/src/data/jsonIO.test.ts
@@ -1,5 +1,5 @@
 import { loadFromFile, saveToFile } from './jsonIO'
-import { PPB_VERSION_NO, type PalletProject } from './interfaces'
+import { PPB_VERSION_NO, type PalletProject, type GuiSettings } from './interfaces'
 
 const baseProject: PalletProject = {
   name: 'Test Project',
@@ -109,7 +109,7 @@ describe('saveToFile', () => {
   test('produces json blob with version', async () => {
     const proj: PalletProject = {
       ...baseProject,
-      guiSettings: {} as any,
+      guiSettings: {} as GuiSettings,
     }
     const blob = saveToFile(proj)
     const text = await blob.text()


### PR DESCRIPTION
## Summary
- calculate allowed XY ranges with pallet overhang
- clamp box placement in `PatternEditor`
- overlay pallet outline inside editor
- pass overhang props from `App`
- tidy test type casting

## Testing
- `npm test --silent`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68517331bf488325a7e40dc87d8c347d