### PR TITLE
Handle shared layer type removal

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -6,6 +6,7 @@ import { PPB_VERSION_NO, LABEL_ORIENTATIONS } from './data/interfaces'
 import { productFits } from './productFit'
 import LayerList from './LayerList'
 import PatternEditor from './PatternEditor'
+import { removeLayer as removeLayerUtil } from './data/project'
 
 const MM_TO_INCH = 25.4
 
@@ -111,12 +112,7 @@ function App() {
   }
 
   const removeLayer = (index: number) => {
-    const name = project.layers[index]
-    setProject((prev) => ({
-      ...prev,
-      layers: prev.layers.filter((_, i) => i !== index),
-      layerTypes: prev.layerTypes.filter((lt) => lt.name !== name),
-    }))
+    setProject((prev) => removeLayerUtil(prev, index))
     setSelectedLayer(null)
   }
 

--- a/pal-in/src/data/project.test.ts
+++ b/pal-in/src/data/project.test.ts
@@ -1,0 +1,45 @@
+import { removeLayer } from './project'
+import { PPB_VERSION_NO, type PalletProject } from './interfaces'
+
+describe('removeLayer', () => {
+  const base: PalletProject = {
+    name: 'P',
+    dimensions: { length: 10, width: 10, maxLoadHeight: 10, palletHeight: 2 },
+    productDimensions: {
+      length: 1,
+      width: 1,
+      height: 1,
+      weight: 1,
+      boxPadding: 0,
+    },
+    guiSettings: { PPB_VERSION_NO },
+    layerTypes: [],
+    layers: [],
+  }
+
+  test('removes layer type when unused', () => {
+    const proj: PalletProject = {
+      ...base,
+      layerTypes: [
+        { name: 'a', class: 'layer' },
+        { name: 'b', class: 'layer' },
+      ],
+      layers: ['a', 'b'],
+    }
+    const result = removeLayer(proj, 1)
+    expect(result.layers).toEqual(['a'])
+    expect(result.layerTypes.find((lt) => lt.name === 'b')).toBeUndefined()
+  })
+
+  test('keeps layer type when still referenced', () => {
+    const proj: PalletProject = {
+      ...base,
+      layerTypes: [{ name: 'a', class: 'layer' }],
+      layers: ['a', 'a'],
+    }
+    const result = removeLayer(proj, 0)
+    expect(result.layers).toEqual(['a'])
+    expect(result.layerTypes.length).toBe(1)
+    expect(result.layerTypes[0].name).toBe('a')
+  })
+})

--- a/pal-in/src/data/project.ts
+++ b/pal-in/src/data/project.ts
@@ -1,0 +1,11 @@
+import type { PalletProject } from './interfaces'
+
+export function removeLayer(project: PalletProject, index: number): PalletProject {
+  const name = project.layers[index]
+  const layers = project.layers.filter((_, i) => i !== index)
+  const stillUsed = layers.includes(name)
+  const layerTypes = stillUsed
+    ? project.layerTypes
+    : project.layerTypes.filter((lt) => lt.name !== name)
+  return { ...project, layers, layerTypes }
+}


### PR DESCRIPTION
## Summary
- update `removeLayer` to keep layer type if it's still referenced
- expose a new helper `removeLayer` in `project.ts`
- cover `removeLayer` logic with unit tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851732caaf483258aa3c7a872dddff3