### PR TITLE
Add grid and overhang indicators

### DIFF
--- a/pal-in/src/App.tsx
+++ b/pal-in/src/App.tsx
@@ -384,6 +384,10 @@ function App() {
               }
               dims={project.dimensions}
               product={project.productDimensions}
+              gridSpacing={100}
+              overhang={project.overhang}
+              overhangSides={project.overhangSides}
+              overhangEnds={project.overhangEnds}
               onChange={(layer) => updateLayerDef(selectedLayer, layer)}
             />
           </div>


### PR DESCRIPTION
## Summary
- improve `PatternEditor` with grid overlay and dashed overhang bounds
- pass project overhang info from `App`

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_68517332e9f08325b7a3d28d5a4c5e7b