### PR TITLE
Add draggable box tool

### DIFF
--- a/pal-in/src/data/jsonIO.test.ts
+++ b/pal-in/src/data/jsonIO.test.ts
@@ -1,5 +1,5 @@
 import { loadFromFile, saveToFile } from './jsonIO'
-import { PPB_VERSION_NO, type PalletProject } from './interfaces'
+import { PPB_VERSION_NO, type PalletProject, type GuiSettings } from './interfaces'
 
 const baseProject: PalletProject = {
   name: 'Test Project',
@@ -109,7 +109,7 @@ describe('saveToFile', () => {
   test('produces json blob with version', async () => {
     const proj: PalletProject = {
       ...baseProject,
-      guiSettings: {} as any,
+      guiSettings: {} as GuiSettings,
     }
     const blob = saveToFile(proj)
     const text = await blob.text()


### PR DESCRIPTION
## Summary
- allow dropping a box icon on the canvas to create a new pattern item
- fix lint error in tests

## Testing
- `npm --prefix pal-in run lint`
- `npm --prefix pal-in test`

------
https://chatgpt.com/codex/tasks/task_e_685173315b388325ab132ef87e4570bd